### PR TITLE
fix(ci): replace setup-python with actions/cache to prevent mise hang

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -18,11 +18,13 @@ runs:
       with:
         version: ${{ env.MISE_VERSION }}
 
-    - name: Setup Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+    - name: Cache Poetry dependencies
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
-        cache: poetry
-        python-version-file: 'pyproject.toml'
+        path: .venv
+        key: poetry-${{ runner.os }}-${{ inputs.cache-version }}-${{ hashFiles('poetry.lock') }}
+        restore-keys: |
+          poetry-${{ runner.os }}-${{ inputs.cache-version }}-
 
     - name: Install dependencies
       run: poetry install


### PR DESCRIPTION
## Summary

- Fixes CI jobs hanging for 5 minutes at the setup step when multiple jobs use the setup composite action concurrently

## Root Cause

`actions/setup-python` with `cache: poetry` hangs when run after `jdx/mise-action`. It calls `poetry config cache-dir` to determine the cache key, which deadlocks against mise's Python shims. Every job using the setup composite action (Python Script Testing, Code Quality & Linting, Fro Bot) stalls silently for 5 minutes until cancelled.

Evidence from [run 22269259975](https://github.com/marcusrbrown/containers/actions/runs/22269259975): `mise install` completes in ~15s, then zero output until the 5-minute cancellation.

## Fix

Removed `actions/setup-python` from the setup composite action — it's redundant since mise already installs Python + Poetry (configured in `mise.toml`). Replaced its dependency caching with `actions/cache` for the `.venv` directory, keyed on `poetry.lock` hash.